### PR TITLE
Port tests to newer rust

### DIFF
--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -1,15 +1,12 @@
-#![feature(old_io, old_path)]
-
 extern crate xml_tree;
 
-use std::old_io::{BufferedReader, File};
+use std::fs::File;
 
 use xml_tree::{build, EventReader};
 
 fn main() {
-    let file = File::open(&Path::new("data/ex1.xml")).unwrap();
-    let reader = BufferedReader::new(file);
-    let mut parser = EventReader::new(reader);
+    let file = File::open("data/ex1.xml").unwrap();
+    let mut parser = EventReader::new(file);
     let res = build(&mut parser);
     match res {
         Err(ref err) => println!("{}", err),

--- a/examples/display.rs
+++ b/examples/display.rs
@@ -1,15 +1,11 @@
-#![feature(old_io, old_path)]
-
 extern crate xml_tree;
 
-use std::old_io::{BufferedReader, File};
-
+use std::fs::File;
 use xml_tree::{build, EventReader};
 
 fn main() {
-    let file = File::open(&Path::new("data/ex1.xml")).unwrap();
-    let reader = BufferedReader::new(file);
-    let mut parser = EventReader::new(reader);
+    let file = File::open("data/ex1.xml").unwrap();
+    let mut parser = EventReader::new(file);
     let res = build(&mut parser);
     match res {
         Err(ref err) => println!("{}", err),

--- a/src/dom/mod.rs
+++ b/src/dom/mod.rs
@@ -11,9 +11,6 @@ mod util;
 
 #[cfg(test)]
 mod tests {
-
-    use std::old_io::{MemReader};
-
     use builder::build;
     use super::{Document, RcElement, RcText};
 
@@ -21,7 +18,7 @@ mod tests {
     use xml::common::XmlVersion;
 
     fn xml_to_doc(text: &str) -> Document {
-        let mut reader = EventReader::new(MemReader::new(text.as_bytes().to_vec()));
+        let mut reader = EventReader::new(text.as_bytes());
         let res = build(&mut reader);
         match res {
             Ok(doc) => doc,


### PR DESCRIPTION
This updates the tests to run with newer Rust.
Mostly consists of eliminating use of old_io.